### PR TITLE
add workflows folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'  
+
+      - name: make amper executable
+        if: runner.os != 'Windows'
+        run: chmod +x ./amper
+
+      - name: run tests
+        run: ./amper test
+
+      - name: build
+        run: ./amper build
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 
 ### IDEA ###
 .idea/
+
+### Github Runners ###
+actions-runner/


### PR DESCRIPTION
this adds the `ci.yml` file for the github actions to work

./amper does not support ktlint or detekt so i have not added them to part of the workflow

when a pull request is made the action runs `./amper test` and `./amper build` to check all tests pass and the project compiles, providing details in the [Actions Page of this repo](https://github.com/Chester-Booth/2850-Library-Miniproject/actions) and it helps ensure the main branch stays working 