### PR TITLE
added query parameters navbar update

### DIFF
--- a/logic/src/com/library/logic/AccountLogic.kt
+++ b/logic/src/com/library/logic/AccountLogic.kt
@@ -1,6 +1,8 @@
 package com.library.logic
 
 import com.library.db.Users
+import com.library.db.UsersTable
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
 suspend fun getUserById(id: Int): Map<String, String>? {
@@ -8,6 +10,23 @@ suspend fun getUserById(id: Int): Map<String, String>? {
         val user = Users.findById(id) ?: return@suspendTransaction null
         mapOf(
             "username" to user.username,
+            "email" to user.email,
+            "address" to user.address,
+            "passwordHash" to user.passwordHash,
+        )
+    }
+}
+
+suspend fun getUserByUsername(username: String): Map<String, String>? {
+    return suspendTransaction {
+        val user =
+            Users
+                .find { UsersTable.username eq username }
+                .singleOrNull()
+                ?: return@suspendTransaction null
+
+        mapOf(
+            "id" to user.id.value.toString(),
             "email" to user.email,
             "address" to user.address,
             "passwordHash" to user.passwordHash,

--- a/server/resources/templates/base.peb
+++ b/server/resources/templates/base.peb
@@ -35,11 +35,11 @@
       <ul class="navbar-nav">
         <li class="nav-item">
             <a class="nav-link" href="/">
-                <i class="bi bi-house-fill"></i>Home</a>
+                <i class="bi bi-house-fill"></i> Home</a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="/loans">
-              <i class="bi bi-bookmarks-fill"></i>Loans</a>
+              <i class="bi bi-bookmarks-fill"></i> Loans</a>
         </li>
       </ul>
 
@@ -47,12 +47,19 @@
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
           <a class="nav-link" href="/search">
-              <i class="bi bi-search"></i>Search</a>
+              <i class="bi bi-search"></i> Search</a>
         </li>
+        {% if isLoggedIn %}
         <li class="nav-item">
-          <a class="nav-link" href="/login">
+          <a class="nav-link" href="/account/{{ id }}">
               <i class="bi bi-person-circle me-1"></i>Account</a>
         </li>
+        {% else %}
+        <li class="nav-item">
+          <a class="nav-link" href="/login">
+              <i class="bi bi-box-arrow-in-right"></i> Login/Register</a>
+        </li>
+        {% endif %}
       </ul>
     </div>
   </div>

--- a/server/src/com/library/server/Home.kt
+++ b/server/src/com/library/server/Home.kt
@@ -5,5 +5,17 @@ import io.ktor.server.pebble.respondTemplate
 import kotlin.collections.mapOf
 
 suspend fun ApplicationCall.homePage() {
-    respondTemplate("index.peb", mapOf())
+    val isLoggedIn = request.queryParameters["login"] == "true"
+    var id = request.queryParameters["id"]
+
+    if (id == null) {
+        id = "n/a"
+    }
+
+    val data: Map<String, Any> =
+        mapOf(
+            "isLoggedIn" to isLoggedIn as Any,
+            "id" to id as Any,
+        )
+    respondTemplate("index.peb", model = data)
 }

--- a/server/src/com/library/server/Login.kt
+++ b/server/src/com/library/server/Login.kt
@@ -1,5 +1,6 @@
 package com.library.server
 
+import com.library.logic.getUserByUsername
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.log
 import io.ktor.server.auth.UserIdPrincipal
@@ -15,5 +16,7 @@ suspend fun ApplicationCall.loginPage() {
 suspend fun ApplicationCall.loginUser() {
     val username = principal<UserIdPrincipal>()?.name.toString()
     application.log.info("User $username logged in")
-    respondRedirect("/")
+    val user = getUserByUsername(username) ?: emptyMap()
+    val id = user["id"] ?: ""
+    respondRedirect("/?login=true&id=$id")
 }


### PR DESCRIPTION
initial 
<img width="276" height="93" alt="image" src="https://github.com/user-attachments/assets/d4b038f5-425b-4de4-8d5a-82b199058a68" />

once signed in 
<img width="213" height="89" alt="image" src="https://github.com/user-attachments/assets/224ca9b2-2a77-46c4-b7a5-2d2a5ecb5fb3" />

this is accomplished by using http://127.0.0.1:8080/?login=true&id=X to detect this

this has a couple of slight security concerns
1. you can access any other users account by simply incrementing ?login=true&id=**X** to see every users address, email and name
2. when you reload the page or go to a different page after `/` the parameters are not carried over so  you cease to be signed in

this is a very basic, insecure patch to allow the account page and login page to be shown during a demonstration
if this were to be developed for a real system sessions tokens should be used but for this microproject, given the deadline this approach gets the job done 